### PR TITLE
PHPUnit TestCase com PHPUnit\Framework\TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "3.7.*",
+        "phpunit/phpunit": "^4.8.36",
         "vinnyfs89/x-dump": "dev-master",
         "vinnyfs89/r-enc": "dev-master"
     },

--- a/library/Zend/Test/PHPUnit/ControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/ControllerTestCase.php
@@ -37,14 +37,14 @@ require_once 'Zend/Registry.php';
 /**
  * Functional testing scaffold for MVC applications
  *
- * @uses       PHPUnit_Framework_TestCase
+ * @uses       PHPUnit\Framework\TestCase
  * @category   Zend
  * @package    Zend_Test
  * @subpackage PHPUnit
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class Zend_Test_PHPUnit_ControllerTestCase extends PHPUnit_Framework_TestCase
+abstract class Zend_Test_PHPUnit_ControllerTestCase extends PHPUnit\Framework\TestCase
 {
     /**
      * @var mixed Bootstrap file path or callback
@@ -1149,7 +1149,7 @@ abstract class Zend_Test_PHPUnit_ControllerTestCase extends PHPUnit_Framework_Te
         $stack = debug_backtrace();
         foreach ($stack as $step) {
             if (isset($step['object'])
-                && $step['object'] instanceof PHPUnit_Framework_TestCase
+                && $step['object'] instanceof PHPUnit\Framework\TestCase
             ) {
                 if (version_compare(PHPUnit_Runner_Version::id(), '3.3.0', 'lt')) {
                     break;

--- a/library/Zend/Tool/Project/Context/Zf/TestLibraryFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/TestLibraryFile.php
@@ -86,7 +86,7 @@ class Zend_Tool_Project_Context_Zf_TestLibraryFile extends Zend_Tool_Project_Con
             'classes' => array(
                 new Zend_CodeGenerator_Php_Class(array(
                     'name' => $className,
-                    'extendedClass' => 'PHPUnit_Framework_TestCase',
+                    'extendedClass' => 'PHPUnit\Framework\TestCase',
                     'methods' => array(
                         new Zend_CodeGenerator_Php_Method(array(
                             'name' => 'setUp',


### PR DESCRIPTION
Usei a notação `PHPUnit\Framework\TestCase` ao invés de `PHPUnit_Framework_TestCase`. Isso irá nos ajudar quando migrarmos para o `PHPUnit 6`, que [não mais suporta _snake case namespaces_](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Também atualizei a versão mínima do PHPUnit para [4.8.36](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21) para manter compatibilidade.