### PR TITLE
[MTUR302019-1951] Não forçar busca receita

### DIFF
--- a/application/modules/proposta/controllers/ManterpropostaincentivofiscalController.php
+++ b/application/modules/proposta/controllers/ManterpropostaincentivofiscalController.php
@@ -1065,7 +1065,7 @@ class Proposta_ManterpropostaincentivofiscalController extends Proposta_GenericC
                 # Se o CNAE estiver vazio, forçar atualização do proponente com os dados do webservice da receita
                 if (empty($cnae)) {
                     $servicoReceita = new ServicosReceitaFederal();
-                    $dadosPessoaJuridica = $servicoReceita->consultarPessoaJuridicaReceitaFederal($proponente->CNPJCPF, true);
+                    $dadosPessoaJuridica = $servicoReceita->consultarPessoaJuridicaReceitaFederal($proponente->CNPJCPF, false);
                     return $dadosPessoaJuridica;
                 }
                 return false;


### PR DESCRIPTION
[MTUR302019-1951] Alterando o parametro que força a busca na api da receita "http://sistemasweb.cultura.gov.br/minc-pessoa/servicos/pessoa_juridica/consultar/CNPJ"